### PR TITLE
feat: Add candidate timeline visualization and refactor schedule domain

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,21 +3,22 @@ import InterviewForm from "./InterviewForm";
 import SchedulingService from "./domain/schedulingService";
 import { JuryDayParameters } from "./domain/parameters";
 import { Slot } from "./domain/interviewSlot";
+import { StructuredSchedule } from "./domain/scheduleTypes";
 import ScheduleTable from "./ScheduleTable";
+import TimelineVisualization from "./TimelineVisualization"; // Import the new component
 import { Col, Form, Row } from "react-bootstrap";
 
 const App: React.FC = () => {
     const date = new Date();
     date.setDate(date.getDate() + 10);
 
-    const [schedule, setSchedule] = useState<Slot[] | null>(null);
+    const [schedule, setSchedule] = useState<StructuredSchedule | null>(null);
     const [juryDate, setJuryDate] = useState<string>(date.toISOString().split('T')[0]);
     const [jobTitle, setJobTitle] = useState<string>('');
 
     const handleFormSubmit = (parameters : JuryDayParameters) => {
-        const newSchedule = SchedulingService.generateSchedule(parameters);
-
-        setSchedule(newSchedule);
+        const newStructuredSchedule = SchedulingService.generateSchedule(parameters);
+        setSchedule(newStructuredSchedule);
     }
 
     const formRef = useRef<HTMLFormElement | null>(null);  
@@ -52,7 +53,12 @@ const App: React.FC = () => {
             </div>
             <InterviewForm onSubmit={handleFormSubmit} />
 
-            { schedule && <ScheduleTable schedule={schedule} date={juryDate} /> }
+            { schedule && (
+                <>
+                    <ScheduleTable schedule={[...schedule.generalSlots, ...schedule.candidateSchedules.flatMap(cs => cs.interviewSlots)]} date={juryDate} />
+                    <TimelineVisualization schedule={schedule} /> {/* Add the new component here */}
+                </>
+            )}
 
         </div>
     )

--- a/src/TimelineVisualization.css
+++ b/src/TimelineVisualization.css
@@ -1,0 +1,62 @@
+.timeline-container {
+    margin-top: 20px;
+    font-family: sans-serif;
+}
+
+.candidate-row {
+    display: flex;
+    align-items: center; /* Align items vertically */
+    margin-bottom: 10px;
+    border: 1px solid #eee;
+    padding: 5px;
+    background-color: #f9f9f9;
+}
+
+.candidate-name {
+    min-width: 150px; /* Ensure candidate names have enough space */
+    font-weight: bold;
+    margin-right: 10px;
+    white-space: nowrap;
+}
+
+.timeline-segments-container {
+    display: flex; /* Segments within this container will be inline */
+    position: relative; /* For potential future absolute positioning of time labels if needed */
+}
+
+.timeline-segment {
+    height: 40px; /* Increased height for better visibility */
+    border-right: 1px solid #ccc; /* Separator between segments */
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column; /* Stack time labels vertically */
+    justify-content: center; /* Center time labels vertically */
+    align-items: center; /* Center time labels horizontally */
+    padding: 0 5px; /* Add some padding */
+    color: white;
+    font-size: 0.75em; /* Smaller font for time labels */
+    overflow: hidden; /* Prevent text overflow */
+    text-align: center;
+}
+
+.timeline-segment:last-child {
+    border-right: none;
+}
+
+.darkblue-segment {
+    background-color: darkblue;
+}
+
+.lightblue-segment {
+    background-color: lightblue;
+    color: #333; /* Darker text for light blue background */
+}
+
+.neutral-segment {
+    background-color: lightgray;
+    color: #333; /* Darker text for light gray background */
+}
+
+.segment-time {
+    display: block; /* Each time on a new line */
+}

--- a/src/TimelineVisualization.tsx
+++ b/src/TimelineVisualization.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { StructuredSchedule, CandidateSchedule } from './domain/scheduleTypes';
+import { InterviewSlot } from './domain/interviewSlot';
+import { Candidate } from './domain/parameters'; // Corrected import path
+import Time from './domain/time';
+import './TimelineVisualization.css';
+
+interface TimelineVisualizationProps {
+  schedule: StructuredSchedule;
+}
+
+const timeToMinutes = (time: Time): number => time.hour * 60 + time.minute;
+const PIXELS_PER_MINUTE = 2;
+
+const TimelineVisualization: React.FC<TimelineVisualizationProps> = ({ schedule }) => {
+  if (!schedule || !schedule.candidateSchedules) {
+    return <p>No schedule data available.</p>;
+  }
+
+  const renderSegment = (startTime: Time, endTime: Time, className: string, label: string) => {
+    const startTimeInMinutes = timeToMinutes(startTime);
+    const endTimeInMinutes = timeToMinutes(endTime);
+    const durationInMinutes = endTimeInMinutes - startTimeInMinutes;
+    
+    if (durationInMinutes <= 0) return null; // Don't render zero or negative duration segments
+
+    const segmentWidth = durationInMinutes * PIXELS_PER_MINUTE;
+
+    return (
+      <div
+        className={`timeline-segment ${className}`}
+        style={{ width: `${segmentWidth}px` }}
+        title={`${label}: ${startTime.toString()} - ${endTime.toString()}`}
+      >
+        <span className="segment-time">{startTime.toString()}</span>
+        <span className="segment-time">{endTime.toString()}</span>
+      </div>
+    );
+  };
+
+  return (
+    <div className="timeline-container">
+      <h2>Candidate Timelines</h2>
+      {schedule.candidateSchedules.map((candidateSchedule: CandidateSchedule, index: number) => (
+        <div key={index} className="candidate-entry"> {/* Changed from candidate-row to avoid conflict if styles differ */}
+          <div className="candidate-name">{candidateSchedule.candidate.name}</div>
+          <div className="timeline-segments-container">
+            {candidateSchedule.interviewSlots.map((interviewSlot: InterviewSlot, slotIndex: number) => (
+              <React.Fragment key={slotIndex}>
+                {/* Welcome Phase */}
+                {renderSegment(
+                  interviewSlot.timeSlot.startTime,
+                  interviewSlot.casusStartTime,
+                  'darkblue-segment',
+                  'Welcome'
+                )}
+                {/* Casus Phase */}
+                {renderSegment(
+                  interviewSlot.casusStartTime,
+                  interviewSlot.correctionStartTime,
+                  'neutral-segment',
+                  'Casus'
+                )}
+                {/* Correction Phase */}
+                {renderSegment(
+                  interviewSlot.correctionStartTime,
+                  interviewSlot.meetingStartTime,
+                  'lightblue-segment',
+                  'Correction'
+                )}
+                {/* Interview Phase */}
+                {renderSegment(
+                  interviewSlot.meetingStartTime,
+                  interviewSlot.debriefingStartTime,
+                  'darkblue-segment',
+                  'Interview'
+                )}
+                {/* Debriefing Phase */}
+                {renderSegment(
+                  interviewSlot.debriefingStartTime,
+                  interviewSlot.timeSlot.endTime,
+                  'lightblue-segment',
+                  'Debriefing'
+                )}
+              </React.Fragment>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default TimelineVisualization;

--- a/src/domain/scheduleTypes.ts
+++ b/src/domain/scheduleTypes.ts
@@ -1,0 +1,12 @@
+import { Candidate } from './candidate';
+import { Slot, InterviewSlot } from './interviewSlot';
+
+export interface StructuredSchedule {
+  generalSlots: Slot[]; // For JuryWelcome, Lunch, FinalDebriefing
+  candidateSchedules: CandidateSchedule[];
+}
+
+export interface CandidateSchedule {
+  candidate: Candidate;
+  interviewSlots: InterviewSlot[]; // All slots directly related to this candidate
+}

--- a/src/domain/schedulingService.ts
+++ b/src/domain/schedulingService.ts
@@ -1,25 +1,38 @@
 import { FinalDebriefingSlot, InterviewSlot, JuryWelcomeSlot, LunchSlot, Slot } from "./interviewSlot";
 import { JuryDayParameters } from "./parameters";
+import { StructuredSchedule, CandidateSchedule } from "./scheduleTypes";
+import { Candidate } from "./candidate";
 
 export default class SchedulingService {
     public static generateSchedule(
         parameters : JuryDayParameters
-    ) : Slot[] {
+    ) : StructuredSchedule {
         
-        const schedule : Slot[] = [];
+        const structuredSchedule: StructuredSchedule = {
+            generalSlots: [],
+            candidateSchedules: [],
+        };
+
         const juryWelcome = new JuryWelcomeSlot(parameters.jurorsStartTime);
-        schedule.push(juryWelcome);
+        structuredSchedule.generalSlots.push(juryWelcome);
 
         let lunchHasHappened = false;
+        let lastSlotEndTime = juryWelcome.timeSlot.endTime;
                 
         for (const candidate of parameters.candidates){
-            const referenceStart = schedule.length > 0 ? schedule.at(-1)!.timeSlot.endTime : parameters.jurorsStartTime;
+            const referenceStart = lastSlotEndTime;
             const nextStartTime = referenceStart
                 .earlier(parameters.interviewParameters.casusDuration)
                 .earlier(parameters.interviewParameters.welcomeDuration);
 
             const appearance = new InterviewSlot(candidate, nextStartTime, parameters.interviewParameters);
-            schedule.push(appearance);
+            
+            const candidateSchedule: CandidateSchedule = {
+                candidate: candidate,
+                interviewSlots: [appearance],
+            };
+            structuredSchedule.candidateSchedules.push(candidateSchedule);
+            lastSlotEndTime = appearance.timeSlot.endTime;
 
             if (!lunchHasHappened
                 && appearance.timeSlot.endTime
@@ -27,13 +40,14 @@ export default class SchedulingService {
                     .isLaterThan(parameters.lunchTargetTime)
             ) {
                 const lunchSlot = new LunchSlot(appearance.timeSlot.endTime, parameters.lunchDuration);
-                schedule.push(lunchSlot);
+                structuredSchedule.generalSlots.push(lunchSlot);
+                lastSlotEndTime = lunchSlot.timeSlot.endTime;
                 lunchHasHappened = true;
             }
         }
 
-        schedule.push(new FinalDebriefingSlot(schedule.at(-1)!.timeSlot.endTime, parameters.finalDebriefingDuration))
+        structuredSchedule.generalSlots.push(new FinalDebriefingSlot(lastSlotEndTime, parameters.finalDebriefingDuration));
 
-        return schedule;
+        return structuredSchedule;
     }
 }


### PR DESCRIPTION
Refactored the scheduling service to produce a more structured schedule object, grouping slots by candidate and separating general agenda items.

Introduced a new `TimelineVisualization` React component that displays:
- Each candidate on a separate row.
- A visual timeline of their interview process.
- Color-coded segments to indicate jury activity:
    - Lightblue: Jury working alone on candidate's materials (correction, debriefing).
    - Darkblue: Jury and candidate together (welcome, interview).
- Timestamps for each segment.

The new visualization is integrated at the end of the main application page.