### PR TITLE
feat: Align candidate timelines with a main day timeline

### DIFF
--- a/src/TimelineVisualization.css
+++ b/src/TimelineVisualization.css
@@ -1,62 +1,118 @@
 .timeline-container {
-    margin-top: 20px;
-    font-family: sans-serif;
+  margin: 20px;
+  font-family: sans-serif;
+  box-sizing: border-box;
 }
 
-.candidate-row {
-    display: flex;
-    align-items: center; /* Align items vertically */
-    margin-bottom: 10px;
-    border: 1px solid #eee;
-    padding: 5px;
-    background-color: #f9f9f9;
+.candidate-entry {
+  display: flex;
+  align-items: center; /* Aligns candidate name and timeline segments container vertically */
+  margin-bottom: 10px;
+  background-color: #f9f9f9;
+  border-radius: 4px;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+  /* border: 1px solid #eee; /* Optional: if a border like old .candidate-row is desired */
+  /* padding: 5px; /* Optional: if padding like old .candidate-row is desired */
 }
 
 .candidate-name {
-    min-width: 150px; /* Ensure candidate names have enough space */
-    font-weight: bold;
-    margin-right: 10px;
-    white-space: nowrap;
+  width: 150px; /* Fixed width */
+  padding: 10px; /* Inner spacing */
+  font-weight: bold;
+  color: #333;
+  border-right: 1px solid #eee; /* Separator line */
+  box-sizing: border-box; /* Padding and border included in width */
+  flex-shrink: 0; /* Prevent shrinking if container gets too small */
 }
 
 .timeline-segments-container {
-    display: flex; /* Segments within this container will be inline */
-    position: relative; /* For potential future absolute positioning of time labels if needed */
+  display: flex;
+  align-items: center; /* Align offset and actual segments vertically */
+  /* padding: 10px; Removed side padding for alignment with header */
+  padding-top: 10px;
+  padding-bottom: 10px;
+  /* No left/right padding here, segments start at the edge of this container */
+  overflow-x: auto; 
+  flex-grow: 1;
+  position: relative; 
 }
 
 .timeline-segment {
-    height: 40px; /* Increased height for better visibility */
-    border-right: 1px solid #ccc; /* Separator between segments */
-    box-sizing: border-box;
-    display: flex;
-    flex-direction: column; /* Stack time labels vertically */
-    justify-content: center; /* Center time labels vertically */
-    align-items: center; /* Center time labels horizontally */
-    padding: 0 5px; /* Add some padding */
-    color: white;
-    font-size: 0.75em; /* Smaller font for time labels */
-    overflow: hidden; /* Prevent text overflow */
-    text-align: center;
-}
-
-.timeline-segment:last-child {
-    border-right: none;
-}
-
-.darkblue-segment {
-    background-color: darkblue;
-}
-
-.lightblue-segment {
-    background-color: lightblue;
-    color: #333; /* Darker text for light blue background */
-}
-
-.neutral-segment {
-    background-color: lightgray;
-    color: #333; /* Darker text for light gray background */
+  height: 40px;
+  margin-right: 2px; /* Gap between segments */
+  color: white;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 8px; /* Text padding inside segments */
+  font-size: 0.8em;
+  border-radius: 3px;
+  box-sizing: border-box;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+  overflow: hidden;
+  white-space: nowrap;
 }
 
 .segment-time {
-    display: block; /* Each time on a new line */
+  font-size: 0.9em;
+}
+
+.darkblue-segment {
+  background-color: #345B63;
+}
+
+.neutral-segment {
+  background-color: #D4B996;
+}
+
+.lightblue-segment {
+  background-color: #A2D5F2;
+  color: #333;
+}
+
+.main-timeline-header {
+  position: relative;
+  height: 30px; 
+  background-color: #e0e0e0;
+  border: 1px solid #ccc;
+  margin-bottom: 10px;
+  box-sizing: border-box;
+  overflow: hidden; 
+  margin-left: 150px; /* Align with the start of timeline-segments-container */
+  /* The 'width' is set inline in the TSX component based on overall times */
+}
+
+.time-marker {
+  position: absolute;
+  top: 0;
+  height: 100%;
+  border-left: 1px solid #aaa;
+  padding-left: 4px; 
+  font-size: 10px;
+  color: #333;
+  display: flex;
+  align-items: center; 
+  box-sizing: border-box;
+  user-select: none;
+}
+
+.time-marker:first-child {
+  padding-left: 2px; 
+}
+
+.main-timeline-header::after {
+  content: '';
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 1px;
+  background-color: #bbb;
+}
+
+.timeline-offset-segment {
+  height: 40px; /* Match .timeline-segment height */
+  margin-right: 2px; /* Consistent with segment margin */
+  box-sizing: border-box;
+  /* background-color: rgba(0,0,0,0.05); /* Optional: for visualizing */
 }

--- a/src/TimelineVisualization.tsx
+++ b/src/TimelineVisualization.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import { StructuredSchedule, CandidateSchedule } from './domain/scheduleTypes';
 import { InterviewSlot } from './domain/interviewSlot';
 import Time from './domain/time';
@@ -11,10 +11,113 @@ interface TimelineVisualizationProps {
 const timeToMinutes = (time: Time): number => time.hour * 60 + time.minute;
 const PIXELS_PER_MINUTE = 2;
 
+interface TimelineHeaderProps {
+  startTime: Time;
+  endTime: Time;
+  pixelsPerMinute: number;
+}
+
+const TimelineHeader: React.FC<TimelineHeaderProps> = ({ startTime, endTime, pixelsPerMinute }) => {
+  const headerWidth = (timeToMinutes(endTime) - timeToMinutes(startTime)) * pixelsPerMinute;
+  const timeMarkers = [];
+
+  // Ensure startTime and endTime are valid before proceeding
+  if (!startTime || !endTime) {
+    return null;
+  }
+
+  const startHour = startTime.hour;
+  // Loop until the hour of the end time.
+  // For example, if endTime is 17:30, we want markers up to 17:00.
+  // If endTime is 17:00, we also want a marker at 17:00.
+  const endHourLoop = endTime.minute === 0 ? endTime.hour + 1 : endTime.hour +1;
+
+
+  for (let hour = startHour; hour < endHourLoop; hour++) {
+    const markerTime = new Time(hour, 0);
+    // Ensure markerTime is not earlier than startTime and not later than endTime
+    if (timeToMinutes(markerTime) < timeToMinutes(startTime) || timeToMinutes(markerTime) > timeToMinutes(endTime)) {
+        // Special case for the very first marker if startTime is not on the hour
+        if (hour === startHour && startTime.minute > 0) {
+            // This marker will be for startTime itself, positioned at 0
+             const position = (timeToMinutes(startTime) - timeToMinutes(startTime)) * pixelsPerMinute;
+             timeMarkers.push(
+                <div
+                    key={`marker-start`}
+                    className="time-marker"
+                    style={{ left: `${position}px` }}
+                    title={startTime.toString()}
+                >
+                    {startTime.toString()}
+                </div>
+            );
+            continue; // continue to next hour for regular hourly markers
+        } else {
+            continue; // Skip markers outside the overall time range
+        }
+    }
+
+
+    const position = (timeToMinutes(markerTime) - timeToMinutes(startTime)) * pixelsPerMinute;
+    timeMarkers.push(
+      <div
+        key={`marker-${hour}`}
+        className="time-marker"
+        style={{ left: `${position}px` }}
+        title={markerTime.toString()}
+      >
+        {markerTime.toString()}
+      </div>
+    );
+  }
+
+  return (
+    <div className="main-timeline-header" style={{ width: `${headerWidth}px` }}>
+      {timeMarkers}
+    </div>
+  );
+};
+
 const TimelineVisualization: React.FC<TimelineVisualizationProps> = ({ schedule }) => {
+  const [overallDayStartTime, setOverallDayStartTime] = useState<Time | null>(null);
+  const [overallDayEndTime, setOverallDayEndTime] = useState<Time | null>(null);
+
+  useEffect(() => {
+    const calculateOverallTimes = () => {
+      if (!schedule || !schedule.candidateSchedules || schedule.candidateSchedules.length === 0) {
+        setOverallDayStartTime(null);
+        setOverallDayEndTime(null);
+        return;
+      }
+
+      let earliestStartTime: Time | null = null;
+      let latestEndTime: Time | null = null;
+
+      schedule.candidateSchedules.forEach(candidateSchedule => {
+        candidateSchedule.interviewSlots.forEach(slot => {
+          if (!earliestStartTime || timeToMinutes(slot.timeSlot.startTime) < timeToMinutes(earliestStartTime)) {
+            earliestStartTime = slot.timeSlot.startTime;
+          }
+          if (!latestEndTime || timeToMinutes(slot.timeSlot.endTime) > timeToMinutes(latestEndTime)) {
+            latestEndTime = slot.timeSlot.endTime;
+          }
+        });
+      });
+
+      setOverallDayStartTime(earliestStartTime);
+      setOverallDayEndTime(latestEndTime);
+    };
+
+    calculateOverallTimes();
+  }, [schedule]);
+
   if (!schedule || !schedule.candidateSchedules) {
     return <p>No schedule data available.</p>;
   }
+
+  // Display overall start and end times (optional, for debugging or UI)
+  // console.log("Overall Day Start Time:", overallDayStartTime?.toString());
+  // console.log("Overall Day End Time:", overallDayEndTime?.toString());
 
   const renderSegment = (startTime: Time, endTime: Time, className: string, label: string) => {
     const startTimeInMinutes = timeToMinutes(startTime);
@@ -40,10 +143,29 @@ const TimelineVisualization: React.FC<TimelineVisualizationProps> = ({ schedule 
   return (
     <div className="timeline-container">
       <h2>Candidate Timelines</h2>
+      {overallDayStartTime && overallDayEndTime && (
+        <TimelineHeader
+          startTime={overallDayStartTime}
+          endTime={overallDayEndTime}
+          pixelsPerMinute={PIXELS_PER_MINUTE}
+        />
+      )}
       {schedule.candidateSchedules.map((candidateSchedule: CandidateSchedule, index: number) => (
         <div key={index} className="candidate-entry"> {/* Changed from candidate-row to avoid conflict if styles differ */}
           <div className="candidate-name">{candidateSchedule.candidate.name}</div>
           <div className="timeline-segments-container">
+            {candidateSchedule.interviewSlots.length > 0 && overallDayStartTime && (() => {
+              // Assuming interviewSlots are sorted or the first one is the earliest for offset calculation
+              const candidateFirstActivityStartTime = candidateSchedule.interviewSlots[0].timeSlot.startTime;
+              const offsetMinutes = timeToMinutes(candidateFirstActivityStartTime) - timeToMinutes(overallDayStartTime);
+
+              if (offsetMinutes > 0) {
+                const offsetWidth = offsetMinutes * PIXELS_PER_MINUTE;
+                // Adding explicit height here as per the example in the subtask description
+                return <div className="timeline-offset-segment" style={{ width: `${offsetWidth}px`, height: '40px' }} />;
+              }
+              return null;
+            })()}
             {candidateSchedule.interviewSlots.map((interviewSlot: InterviewSlot, slotIndex: number) => (
               <React.Fragment key={slotIndex}>
                 {/* Welcome Phase */}


### PR DESCRIPTION
Implemented a main timeline header that displays the overall time range for the scheduled interviews. Candidate timelines are now visually aligned with this main timeline.

Key changes:
- Calculated `overallDayStartTime` and `overallDayEndTime` based on all candidate activities.
- Added a `TimelineHeader` component to display hourly markers for the entire day's schedule.
- Introduced an offset segment at the beginning of each candidate's timeline to ensure their activities align correctly under the main timeline header.
- Adjusted CSS for `TimelineVisualization.css` to ensure proper horizontal and vertical alignment of the header, candidate names, and their timelines.
- Styles for candidate entries and segments were updated for a consistent look and feel.

This change provides a clearer overview of the day's schedule and how each candidate's interviews fit into the larger picture.