### PR TITLE
feat: Integrate global slots into timeline and table

### DIFF
--- a/src/ScheduleTable.tsx
+++ b/src/ScheduleTable.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { FinalDebriefingSlot, InterviewSlot, JuryWelcomeSlot, LunchSlot, Slot } from "./domain/interviewSlot";
+import Time from "./domain/time"; // Import Time
 import { FaPause, FaUser, FaEdit, FaCopy } from 'react-icons/fa';
 import Clipboard from 'react-clipboard.js';
 
@@ -8,9 +9,20 @@ type ScheduleTableProps = {
     date : string;
 }
 
+// Helper function for time comparison
+const timeToMinutes = (time: Time): number => time.hour * 60 + time.minute;
+
 const ScheduleTable: React.FC<ScheduleTableProps> = ({schedule, date}) => {
     let typedDate = new Date(date);
     date = typedDate.toLocaleDateString();
+
+    // Sort the schedule by start time
+    const sortedSchedule = [...schedule].sort((a, b) => {
+        const timeA = timeToMinutes(a.timeSlot.startTime);
+        const timeB = timeToMinutes(b.timeSlot.startTime);
+        return timeA - timeB;
+    });
+
     return (
 <div>
     <div id="clippy-target">
@@ -30,7 +42,7 @@ const ScheduleTable: React.FC<ScheduleTableProps> = ({schedule, date}) => {
                 <th>Confirmé ?</th>
             </thead>
             <tbody>
-            {schedule.map((slot, index) => {
+            {sortedSchedule.map((slot, index) => {
                 if (slot instanceof InterviewSlot) {
                     return <InterviewSlotRow key={index} slot={slot} />;
                 } else if (slot instanceof LunchSlot) {

--- a/src/TimelineVisualization.css
+++ b/src/TimelineVisualization.css
@@ -116,3 +116,48 @@
   box-sizing: border-box;
   /* background-color: rgba(0,0,0,0.05); /* Optional: for visualizing */
 }
+
+/* Styles for Global Slot Entries */
+.global-slot-entry {
+  display: flex;
+  align-items: center;
+  margin-bottom: 8px; /* Consistent with candidate-entry or slightly different */
+  /* padding: 5px; /* Optional: if global-slot-name and timeline-segments-container don't have enough */
+  border: 1px solid #ddd; 
+  border-radius: 4px;
+  background-color: #f0f0f0; /* Slightly different background from candidates */
+}
+
+.global-slot-name {
+  width: 150px; /* Match candidate-name width */
+  padding: 10px; /* Match candidate-name padding for alignment */
+  font-weight: bold;
+  color: #333; /* Match candidate-name color */
+  border-right: 1px solid #eee; /* Match candidate-name border */
+  box-sizing: border-box; 
+  flex-shrink: 0; 
+  white-space: nowrap; /* Prevent name from wrapping */
+}
+
+/* Specific styles for global timeline segments */
+/* Base properties are inherited from .timeline-segment */
+
+.lunch-segment {
+  background-color: #6EAA7C; /* Calm green */
+  color: white;
+}
+
+.final-debriefing-segment {
+  background-color: #7B6D8D; /* Muted purple */
+  color: white;
+}
+
+.jury-welcome-segment {
+  background-color: #A57C6A; /* Neutral brown */
+  color: white;
+}
+
+.unknown-segment { /* Fallback for any other global slot types */
+  background-color: #777777; /* Grey */
+  color: white;
+}

--- a/src/TimelineVisualization.tsx
+++ b/src/TimelineVisualization.tsx
@@ -1,11 +1,17 @@
 import React, { useState, useEffect } from 'react';
-import { StructuredSchedule, CandidateSchedule } from './domain/scheduleTypes';
-import { InterviewSlot } from './domain/interviewSlot';
+import { Slot, InterviewSlot, LunchSlot, FinalDebriefingSlot, JuryWelcomeSlot } from './domain/interviewSlot';
+import { Candidate } from './domain/parameters'; // Assuming Candidate is here
 import Time from './domain/time';
 import './TimelineVisualization.css';
 
 interface TimelineVisualizationProps {
-  schedule: StructuredSchedule;
+  slots: Slot[];
+}
+
+// Define a type for the processed candidate schedule structure
+interface ProcessedCandidateSchedule {
+  candidate: Candidate;
+  interviewSlots: InterviewSlot[];
 }
 
 const timeToMinutes = (time: Time): number => time.hour * 60 + time.minute;
@@ -21,25 +27,17 @@ const TimelineHeader: React.FC<TimelineHeaderProps> = ({ startTime, endTime, pix
   const headerWidth = (timeToMinutes(endTime) - timeToMinutes(startTime)) * pixelsPerMinute;
   const timeMarkers = [];
 
-  // Ensure startTime and endTime are valid before proceeding
   if (!startTime || !endTime) {
     return null;
   }
 
   const startHour = startTime.hour;
-  // Loop until the hour of the end time.
-  // For example, if endTime is 17:30, we want markers up to 17:00.
-  // If endTime is 17:00, we also want a marker at 17:00.
   const endHourLoop = endTime.minute === 0 ? endTime.hour + 1 : endTime.hour +1;
-
 
   for (let hour = startHour; hour < endHourLoop; hour++) {
     const markerTime = new Time(hour, 0);
-    // Ensure markerTime is not earlier than startTime and not later than endTime
     if (timeToMinutes(markerTime) < timeToMinutes(startTime) || timeToMinutes(markerTime) > timeToMinutes(endTime)) {
-        // Special case for the very first marker if startTime is not on the hour
         if (hour === startHour && startTime.minute > 0) {
-            // This marker will be for startTime itself, positioned at 0
              const position = (timeToMinutes(startTime) - timeToMinutes(startTime)) * pixelsPerMinute;
              timeMarkers.push(
                 <div
@@ -51,13 +49,11 @@ const TimelineHeader: React.FC<TimelineHeaderProps> = ({ startTime, endTime, pix
                     {startTime.toString()}
                 </div>
             );
-            continue; // continue to next hour for regular hourly markers
+            continue; 
         } else {
-            continue; // Skip markers outside the overall time range
+            continue; 
         }
     }
-
-
     const position = (timeToMinutes(markerTime) - timeToMinutes(startTime)) * pixelsPerMinute;
     timeMarkers.push(
       <div
@@ -78,53 +74,88 @@ const TimelineHeader: React.FC<TimelineHeaderProps> = ({ startTime, endTime, pix
   );
 };
 
-const TimelineVisualization: React.FC<TimelineVisualizationProps> = ({ schedule }) => {
+// Helper functions for global slots
+const getGlobalSlotName = (slot: Slot): string => {
+  if (slot instanceof LunchSlot) return "Lunch Break";
+  if (slot instanceof FinalDebriefingSlot) return "Final Debriefing";
+  if (slot instanceof JuryWelcomeSlot) return "Jury Welcome";
+  return "Unknown Event";
+};
+
+const getGlobalSlotSegmentClass = (slot: Slot): string => {
+  if (slot instanceof LunchSlot) return "lunch-segment";
+  if (slot instanceof FinalDebriefingSlot) return "final-debriefing-segment";
+  if (slot instanceof JuryWelcomeSlot) return "jury-welcome-segment";
+  return "unknown-segment";
+};
+
+const TimelineVisualization: React.FC<TimelineVisualizationProps> = ({ slots }) => {
   const [overallDayStartTime, setOverallDayStartTime] = useState<Time | null>(null);
   const [overallDayEndTime, setOverallDayEndTime] = useState<Time | null>(null);
+  const [processedCandidateSchedules, setProcessedCandidateSchedules] = useState<ProcessedCandidateSchedule[]>([]);
+  const [processedGlobalSlots, setProcessedGlobalSlots] = useState<Slot[]>([]);
 
   useEffect(() => {
     const calculateOverallTimes = () => {
-      if (!schedule || !schedule.candidateSchedules || schedule.candidateSchedules.length === 0) {
+      if (!slots || slots.length === 0) {
         setOverallDayStartTime(null);
         setOverallDayEndTime(null);
         return;
       }
-
       let earliestStartTime: Time | null = null;
       let latestEndTime: Time | null = null;
-
-      schedule.candidateSchedules.forEach(candidateSchedule => {
-        candidateSchedule.interviewSlots.forEach(slot => {
-          if (!earliestStartTime || timeToMinutes(slot.timeSlot.startTime) < timeToMinutes(earliestStartTime)) {
-            earliestStartTime = slot.timeSlot.startTime;
-          }
-          if (!latestEndTime || timeToMinutes(slot.timeSlot.endTime) > timeToMinutes(latestEndTime)) {
-            latestEndTime = slot.timeSlot.endTime;
-          }
-        });
+      slots.forEach(slot => {
+        if (!earliestStartTime || timeToMinutes(slot.timeSlot.startTime) < timeToMinutes(earliestStartTime)) {
+          earliestStartTime = slot.timeSlot.startTime;
+        }
+        if (!latestEndTime || timeToMinutes(slot.timeSlot.endTime) > timeToMinutes(latestEndTime)) {
+          latestEndTime = slot.timeSlot.endTime;
+        }
       });
-
       setOverallDayStartTime(earliestStartTime);
       setOverallDayEndTime(latestEndTime);
     };
 
     calculateOverallTimes();
-  }, [schedule]);
 
-  if (!schedule || !schedule.candidateSchedules) {
+    if (!slots || slots.length === 0) {
+      setProcessedCandidateSchedules([]);
+      setProcessedGlobalSlots([]);
+      return;
+    }
+
+    const interviewSlotsByCandidate = new Map<string, { candidate: Candidate, interviewSlots: InterviewSlot[] }>();
+    const globalSlots: Slot[] = [];
+
+    slots.forEach(slot => {
+      if (slot instanceof InterviewSlot) {
+        const candidateId = slot.candidate.id;
+        if (!interviewSlotsByCandidate.has(candidateId)) {
+          interviewSlotsByCandidate.set(candidateId, { candidate: slot.candidate, interviewSlots: [] });
+        }
+        interviewSlotsByCandidate.get(candidateId)!.interviewSlots.push(slot);
+      } else if (slot instanceof LunchSlot || slot instanceof FinalDebriefingSlot || slot instanceof JuryWelcomeSlot) {
+        globalSlots.push(slot);
+      }
+    });
+
+    setProcessedCandidateSchedules(Array.from(interviewSlotsByCandidate.values()));
+    // Sort global slots by start time before setting state
+    globalSlots.sort((a, b) => timeToMinutes(a.timeSlot.startTime) - timeToMinutes(b.timeSlot.startTime));
+    setProcessedGlobalSlots(globalSlots);
+
+  }, [slots]);
+
+  if (!slots || slots.length === 0) {
     return <p>No schedule data available.</p>;
   }
-
-  // Display overall start and end times (optional, for debugging or UI)
-  // console.log("Overall Day Start Time:", overallDayStartTime?.toString());
-  // console.log("Overall Day End Time:", overallDayEndTime?.toString());
 
   const renderSegment = (startTime: Time, endTime: Time, className: string, label: string) => {
     const startTimeInMinutes = timeToMinutes(startTime);
     const endTimeInMinutes = timeToMinutes(endTime);
     const durationInMinutes = endTimeInMinutes - startTimeInMinutes;
     
-    if (durationInMinutes <= 0) return null; // Don't render zero or negative duration segments
+    if (durationInMinutes <= 0) return null;
 
     const segmentWidth = durationInMinutes * PIXELS_PER_MINUTE;
 
@@ -150,53 +181,46 @@ const TimelineVisualization: React.FC<TimelineVisualizationProps> = ({ schedule 
           pixelsPerMinute={PIXELS_PER_MINUTE}
         />
       )}
-      {schedule.candidateSchedules.map((candidateSchedule: CandidateSchedule, index: number) => (
-        <div key={index} className="candidate-entry"> {/* Changed from candidate-row to avoid conflict if styles differ */}
+      {/* Render Processed Candidate Schedules */}
+      {processedCandidateSchedules.map((candidateSchedule, index) => (
+        <div key={candidateSchedule.candidate.id || index} className="candidate-entry">
           <div className="candidate-name">{candidateSchedule.candidate.name}</div>
           <div className="timeline-segments-container">
             {candidateSchedule.interviewSlots.length > 0 && overallDayStartTime && (() => {
-              // Assuming interviewSlots are sorted or the first one is the earliest for offset calculation
               const candidateFirstActivityStartTime = candidateSchedule.interviewSlots[0].timeSlot.startTime;
               const offsetMinutes = timeToMinutes(candidateFirstActivityStartTime) - timeToMinutes(overallDayStartTime);
-
               if (offsetMinutes > 0) {
                 const offsetWidth = offsetMinutes * PIXELS_PER_MINUTE;
-                // Adding explicit height here as per the example in the subtask description
                 return <div className="timeline-offset-segment" style={{ width: `${offsetWidth}px`, height: '40px' }} />;
               }
               return null;
             })()}
-            {candidateSchedule.interviewSlots.map((interviewSlot: InterviewSlot, slotIndex: number) => (
+            {candidateSchedule.interviewSlots.map((interviewSlot, slotIndex) => (
               <React.Fragment key={slotIndex}>
-                {/* Welcome Phase */}
                 {renderSegment(
                   interviewSlot.timeSlot.startTime,
                   interviewSlot.casusStartTime,
                   'darkblue-segment',
                   'Welcome'
                 )}
-                {/* Casus Phase */}
                 {renderSegment(
                   interviewSlot.casusStartTime,
                   interviewSlot.correctionStartTime,
                   'neutral-segment',
                   'Casus'
                 )}
-                {/* Correction Phase */}
                 {renderSegment(
                   interviewSlot.correctionStartTime,
                   interviewSlot.meetingStartTime,
                   'lightblue-segment',
                   'Correction'
                 )}
-                {/* Interview Phase */}
                 {renderSegment(
                   interviewSlot.meetingStartTime,
                   interviewSlot.debriefingStartTime,
                   'darkblue-segment',
                   'Interview'
                 )}
-                {/* Debriefing Phase */}
                 {renderSegment(
                   interviewSlot.debriefingStartTime,
                   interviewSlot.timeSlot.endTime,
@@ -208,6 +232,36 @@ const TimelineVisualization: React.FC<TimelineVisualizationProps> = ({ schedule 
           </div>
         </div>
       ))}
+
+      {/* Render Processed Global Slots */}
+      {processedGlobalSlots.map((globalSlot, index) => {
+        const slotName = getGlobalSlotName(globalSlot);
+        const segmentClass = getGlobalSlotSegmentClass(globalSlot);
+        let offsetSegmentRender = null;
+
+        if (overallDayStartTime && globalSlot.timeSlot.startTime) {
+          const offsetMinutes = timeToMinutes(globalSlot.timeSlot.startTime) - timeToMinutes(overallDayStartTime);
+          if (offsetMinutes > 0) {
+            const offsetWidth = offsetMinutes * PIXELS_PER_MINUTE;
+            offsetSegmentRender = <div className="timeline-offset-segment" style={{ width: `${offsetWidth}px`, height: '40px' }} />;
+          }
+        }
+
+        return (
+          <div key={`global-${index}`} className="global-slot-entry">
+            <div className="global-slot-name">{slotName}</div>
+            <div className="timeline-segments-container">
+              {offsetSegmentRender}
+              {renderSegment(
+                globalSlot.timeSlot.startTime,
+                globalSlot.timeSlot.endTime,
+                segmentClass,
+                slotName
+              )}
+            </div>
+          </div>
+        );
+      })}
     </div>
   );
 };


### PR DESCRIPTION
Added Lunch, Final Debriefing, and Jury Welcome slots to both the ScheduleTable and the TimelineVisualization.

In ScheduleTable:
- All schedule entries, including global slots, are now sorted and displayed in strict chronological order by their start times.

In TimelineVisualization:
- Global slots (Lunch, Final Debriefing, Jury Welcome) are now rendered as distinct, styled rows.
- Each global slot is correctly offset to align with the main timeline header.
- Specific background colors are applied to differentiate global slot types.
- The overall timeline range (`overallDayStartTime`, `overallDayEndTime`) now correctly includes these global slots.
- Data handling in TimelineVisualization was refactored to accept a flat list of all `Slot` types.

This provides a more comprehensive view of the entire day's schedule in both tabular and visual formats.