### PR TITLE
fix: Resolve TypeScript errors in App and TimelineVisualization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,7 @@ const App: React.FC = () => {
             { schedule && (
                 <>
                     <ScheduleTable schedule={[...schedule.generalSlots, ...schedule.candidateSchedules.flatMap(cs => cs.interviewSlots)]} date={juryDate} />
-                    <TimelineVisualization schedule={schedule} /> {/* Add the new component here */}
+                    <TimelineVisualization slots={[...schedule.generalSlots, ...schedule.candidateSchedules.flatMap(cs => cs.interviewSlots)]} />
                 </>
             )}
 

--- a/src/TimelineVisualization.tsx
+++ b/src/TimelineVisualization.tsx
@@ -129,11 +129,11 @@ const TimelineVisualization: React.FC<TimelineVisualizationProps> = ({ slots }) 
 
     slots.forEach(slot => {
       if (slot instanceof InterviewSlot) {
-        const candidateId = slot.candidate.id;
-        if (!interviewSlotsByCandidate.has(candidateId)) {
-          interviewSlotsByCandidate.set(candidateId, { candidate: slot.candidate, interviewSlots: [] });
+        const candidateName = slot.candidate.name; // Changed from candidate.id
+        if (!interviewSlotsByCandidate.has(candidateName)) {
+          interviewSlotsByCandidate.set(candidateName, { candidate: slot.candidate, interviewSlots: [] });
         }
-        interviewSlotsByCandidate.get(candidateId)!.interviewSlots.push(slot);
+        interviewSlotsByCandidate.get(candidateName)!.interviewSlots.push(slot);
       } else if (slot instanceof LunchSlot || slot instanceof FinalDebriefingSlot || slot instanceof JuryWelcomeSlot) {
         globalSlots.push(slot);
       }
@@ -183,7 +183,7 @@ const TimelineVisualization: React.FC<TimelineVisualizationProps> = ({ slots }) 
       )}
       {/* Render Processed Candidate Schedules */}
       {processedCandidateSchedules.map((candidateSchedule, index) => (
-        <div key={candidateSchedule.candidate.id || index} className="candidate-entry">
+        <div key={candidateSchedule.candidate.name || index} className="candidate-entry"> {/* Changed from candidate.id */}
           <div className="candidate-name">{candidateSchedule.candidate.name}</div>
           <div className="timeline-segments-container">
             {candidateSchedule.interviewSlots.length > 0 && overallDayStartTime && (() => {


### PR DESCRIPTION
This commit addresses two TypeScript errors:

1.  TS2322 in App.tsx: Corrected the props passed to the TimelineVisualization component. It now receives the `slots` prop (a flat array of all schedule slots) instead of the old `schedule` prop (StructuredSchedule object), aligning with recent changes to TimelineVisualization's expected props.

2.  TS2339 in TimelineVisualization.tsx: Resolved an error where `candidate.id` was accessed, but the Candidate type does not define an `id` property. Updated the code to use `candidate.name` as the identifier for grouping interview slots and for React key props.

The project now builds successfully with these corrections.