### PR TITLE
feat: Enhance timeline visualization and order

### DIFF
--- a/src/TimelineVisualization.css
+++ b/src/TimelineVisualization.css
@@ -139,21 +139,27 @@
   white-space: nowrap; /* Prevent name from wrapping */
 }
 
+/* Specific styles for candidate interview segments */
+.welcome-segment {
+  background-color: #90EE90; /* lightgreen */
+  color: #333; /* Dark text for good contrast */
+}
+
 /* Specific styles for global timeline segments */
 /* Base properties are inherited from .timeline-segment */
 
 .lunch-segment {
-  background-color: #6EAA7C; /* Calm green */
+  background-color: #345B63; /* Dark Blue, same as .darkblue-segment */
   color: white;
 }
 
 .final-debriefing-segment {
-  background-color: #7B6D8D; /* Muted purple */
+  background-color: #345B63; /* Dark Blue, same as .darkblue-segment */
   color: white;
 }
 
 .jury-welcome-segment {
-  background-color: #A57C6A; /* Neutral brown */
+  background-color: #345B63; /* Dark Blue, same as .darkblue-segment */
   color: white;
 }
 


### PR DESCRIPTION
Implements several visual improvements to the candidate timeline:

- Changed the "Welcome" phase segment for candidates to be light green for better visual differentiation.
- Refactored data processing and rendering logic in TimelineVisualization to display candidate timelines and global slots (Jury Welcome, Lunch, Final Debriefing) in a single, chronologically interleaved list. This matches the order presented in your schedule table.
- Changed the background color of Jury Welcome, Lunch, and Final Debriefing timeline segments to dark blue for visual consistency with other key event types.