### PR TITLE
⚡ optimize LocalStorage access in LocalSessionRepository

### DIFF
--- a/src/repositories/LocalSessionRepository.ts
+++ b/src/repositories/LocalSessionRepository.ts
@@ -18,7 +18,7 @@ export class LocalSessionRepository implements SessionRepository {
         }
     }
 
-    static saveToStorage(session: SavedSession): void {
+    static saveToStorage(session: SavedSession): SavedSession[] {
         const sessions = LocalSessionRepository.readAll();
         const existingIndex = sessions.findIndex(s => s.id === session.id);
 
@@ -29,16 +29,19 @@ export class LocalSessionRepository implements SessionRepository {
         }
 
         localStorage.setItem(LocalSessionRepository.STORAGE_KEY, JSON.stringify(sessions));
+        return sessions;
     }
 
-    static deleteFromStorage(id: string): void {
+    static deleteFromStorage(id: string): SavedSession[] {
         const sessions = LocalSessionRepository.readAll();
         const filtered = sessions.filter(s => s.id !== id);
         localStorage.setItem(LocalSessionRepository.STORAGE_KEY, JSON.stringify(filtered));
+        return filtered;
     }
 
-    private static notify() {
-        const sessions = LocalSessionRepository.readAll().map(s => ({
+    private static notify(updatedSessions?: SavedSession[]) {
+        const rawSessions = updatedSessions || LocalSessionRepository.readAll();
+        const sessions = rawSessions.map(s => ({
             ...s,
             syncStatus: 'local' as const
         }));
@@ -61,12 +64,12 @@ export class LocalSessionRepository implements SessionRepository {
     }
 
     async save(session: SavedSession): Promise<void> {
-        LocalSessionRepository.saveToStorage(session);
-        LocalSessionRepository.notify();
+        const updated = LocalSessionRepository.saveToStorage(session);
+        LocalSessionRepository.notify(updated);
     }
 
     async delete(id: string): Promise<void> {
-        LocalSessionRepository.deleteFromStorage(id);
-        LocalSessionRepository.notify();
+        const updated = LocalSessionRepository.deleteFromStorage(id);
+        LocalSessionRepository.notify(updated);
     }
 }


### PR DESCRIPTION
### 💡 **What:**
Optimized `LocalSessionRepository` to reduce redundant `localStorage` access.

### 🎯 **Why:**
Previously, `save` and `delete` methods would:
1. Call `saveToStorage` / `deleteFromStorage` which reads from `localStorage`, modifies the data, and writes back.
2. Call `notify` which reads from `localStorage` again to get the data it just wrote.

This second read is redundant as the updated data is already available in memory after step 1.

### 📊 **Measured Improvement:**
- **Baseline:** 2 `getItem` calls per `save`/`delete` operation.
- **Optimized:** 1 `getItem` call per `save`/`delete` operation.
- **Result:** 50% reduction in `localStorage` read operations for these methods, which also eliminates associated JSON parsing overhead.

Verified using a standalone measurement script `verification/measure_io.js` (deleted before submission) and through manual code review. Functional tests were attempted but the environment lacked the necessary `react-scripts` dependency.


---
*PR created automatically by Jules for task [5265363485312915611](https://jules.google.com/task/5265363485312915611) started by @jmhumblet*